### PR TITLE
Add security features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 lib
+node_modules
+*.orig
+*.log
+.DS_Store
+Thumbs.db

--- a/blueprint/.gitignore
+++ b/blueprint/.gitignore
@@ -1,1 +1,7 @@
 .build
+lib
+node_modules
+*.orig
+*.log
+.DS_Store
+Thumbs.db

--- a/blueprint/package.json
+++ b/blueprint/package.json
@@ -35,6 +35,8 @@
     "express": "4.13.4",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",
+    "helmet": "1.1.0",
+    "hpp": "0.2.0",
     "if-env": "1.0.0",
     "karma": "0.13.21",
     "karma-chrome-launcher": "0.2.2",


### PR DESCRIPTION
Hey! Thanks for making this project. I actually recently started making my own called [preheat](https://github.com/mike-engel/preheat), but this one seems more comprehensive.

Anyway, this PR is to add some security features by default. They include [hpp](https://github.com/analog-nico/hpp) and most of the features from [helmet](https://github.com/helmetjs/helmet). Most options are OK as defaults and should only add security without compromising anything.

CSP is the one I'd like to get your thoughts on (if you like this PR), since that can have the widest range of possibly hidden effects. In case you're not familiar with CSP, you can read more about it on [html5 rocks](http://www.html5rocks.com/en/tutorials/security/content-security-policy/). The default provided here would only allow scripts, styles, images, fonts, and connections (like websockets) from the same domain.

If there's interest, I could also put together a PR for HTTPS with self-signed certs being generated during the init phase, which would allow HTTP/2 and SPDY to be enabled.
