### PR TITLE
API for redux/alt/flux and resolver libs

### DIFF
--- a/blueprint/modules/components/Document.js
+++ b/blueprint/modules/components/Document.js
@@ -32,7 +32,7 @@ const Document = React.createClass({
           <div id="app" dangerouslySetInnerHTML={{ __html: content }}/>
           <script dangerouslySetInnerHTML={{ __html: shims }}/>
           {initialState &&
-            <script dangerouslySetInnerHTML={{ __html: `window.INITIAL_STATE = ${JSON.stringify(initialState)};`}}/>
+            <script dangerouslySetInnerHTML={{ __html: `window.INITIAL_STATE = ${JSON.stringify(initialState)};` }}/>
           }
           {scripts}
         </body>

--- a/blueprint/modules/components/Document.js
+++ b/blueprint/modules/components/Document.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const { arrayOf, string, node } = React.PropTypes
+const { arrayOf, string, node, object } = React.PropTypes
 
 const shims = `
   (String.prototype.trim && Function.prototype.bind) || document.write('<script src="/es5-shim.js"><\\/script>');
@@ -14,11 +14,12 @@ const Document = React.createClass({
     styles: arrayOf(node),
     scripts: arrayOf(node),
     content: string,
-    title: string
+    title: string,
+    initialState: object
   },
 
   render() {
-    const { styles, scripts, content, title } = this.props
+    const { styles, scripts, content, title, initialState } = this.props
 
     return (
       <html>
@@ -30,6 +31,9 @@ const Document = React.createClass({
         <body>
           <div id="app" dangerouslySetInnerHTML={{ __html: content }}/>
           <script dangerouslySetInnerHTML={{ __html: shims }}/>
+          {initialState &&
+            <script dangerouslySetInnerHTML={{ __html: `window.INITIAL_STATE = ${JSON.stringify(initialState)};`}}/>
+          }
           {scripts}
         </body>
       </html>
@@ -39,4 +43,3 @@ const Document = React.createClass({
 })
 
 export default Document
-

--- a/modules/PublicServerAPI.js
+++ b/modules/PublicServerAPI.js
@@ -102,14 +102,15 @@ function sendWithReactRouter({ req, res, renderApp, renderDocument, webpackStats
   } else if (req.method !== 'GET') {
     sendNoRoutesMatched(res)
   } else {
-    renderApp(routerProps, (err, appElement) => {
+    renderApp(routerProps, (err, appElement, initialState = {}) => {
       const status = err ? err.status : (lastRoute.status || 200)
       const content = getContent(req, appElement)
       renderDocument({
         title: flushTitle(),
         content: content,
         scripts: getJavaScriptTags(webpackStats),
-        styles: getStyleTags(webpackStats)
+        styles: getStyleTags(webpackStats),
+        initialState
       }, (err, documentElement) => {
         if (err) {
           onError(err, req, res)


### PR DESCRIPTION
This would allow for flux libs to pass Document.js a state object for rehydration on the client. 

Redux Example:  

``` javascript
// server.js
...
function renderApp(props, cb) {
  const use404 = props.location.pathname === '/throws-an-error'
  const err = use404 ? { status: 404 } : null
  const store = createStore(reducer, applyMiddleware(thunk))
  const { components, location } = props
  mySuperResolver(components, location, () =>  { // handwaiving
    const appElement = <Provider store={store}><RouterContext {...props}/></Provider>
    const initialState = store.getState()
    cb(err, appElement, initalState)
  }
}
...
```
