### PR TITLE
Fixes 404 error for shims

### DIFF
--- a/create-react-project/blueprint/modules/components/Document.js
+++ b/create-react-project/blueprint/modules/components/Document.js
@@ -4,9 +4,9 @@ import favicon from '../favicon.ico'
 const { arrayOf, string, node, object } = React.PropTypes
 
 const shims = `
-  (String.prototype.trim && Function.prototype.bind) || document.write('<script src="/es5-shim.js"><\\/script>');
-  window.Promise || document.write('<script src="/Promise.js"><\\/script>');
-  window.fetch || document.write('<script src="/fetch.js"><\\/script>');
+  (String.prototype.trim && Function.prototype.bind) || document.write('<script src="/es5-shim.min.js"><\\/script>');
+  window.Promise || document.write('<script src="/Promise.min.js"><\\/script>');
+  window.fetch || document.write('<script src="/fetch.min.js"><\\/script>');
 `
 
 const Document = React.createClass({


### PR DESCRIPTION
Noticed a 404 in my console in Safari and FF.  Static shims are minified, with '.min.' in the file name.  However, the const shims does not contain the '.min' in the file name.

<img width="711" alt="screen shot 2016-04-07 at 10 16 39 pm" src="https://cloud.githubusercontent.com/assets/10407222/14374041/7b9b1f90-fd0e-11e5-869e-f7673d06e421.PNG">
